### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/src/flows/register/helpers/format.ts
+++ b/src/flows/register/helpers/format.ts
@@ -1,5 +1,5 @@
 export const escapeMarkdownV2 = (text: string) => {
-  return text.replace(/[_*[\]()~`>#+\-=|{}.!]/g, '\\$&')
+  return text.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&')
 }
 
 export function formatConfirmationMessage(userData: any) {


### PR DESCRIPTION
Potential fix for [https://github.com/AJBogo9/activity-challenge-bot/security/code-scanning/5](https://github.com/AJBogo9/activity-challenge-bot/security/code-scanning/5)

In general, when writing an escaping routine, you must include *all* relevant metacharacters in the pattern, including the escape character itself (`\`). For MarkdownV2, that means escaping backslash and all special punctuation characters as documented, using a global regex so every occurrence is escaped.

The best fix here is to update the regular expression in `escapeMarkdownV2` so that it also matches backslashes, and keep the same replacement strategy (`'\\$&'`, which prepends a backslash to each matched character). Concretely, in `src/flows/register/helpers/format.ts`, line 2 should be changed from:

```ts
return text.replace(/[_*[\]()~`>#+\-=|{}.!]/g, '\\$&')
```

to something like:

```ts
return text.replace(/[\_\*\[\]\(\)\~\`\>\#\+\-\=\|\{\}\.\!\\]/g, '\\$&')
```

or equivalently, keeping the same style but adding `\\` inside the character class. This ensures that any `\` in user input is also escaped to `\\`, preventing it from unintentionally affecting the rest of the escaped string. No new imports or helper methods are required; only the regex in this one function needs updating.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
